### PR TITLE
Fixes for wishlist and API spam

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -28,7 +28,7 @@ function page_constructor() {
 
 /* This simple filter function checks to see if the game's Steam ID is in the list of known GFN games */
 const isSteamIdOnGeForceNow = gameNode => {
-    const steamID = gameNode.getAttribute('data-ds-appid') // Get the game's Steam ID from its data attribute
+    const steamID = gameNode.getAttribute('data-ds-appid')  ?? gameNode.getAttribute('data-app-id') // Get the game's Steam ID from its data attributes. Most pages use ds-appid, but the wishlist uses app-id
     return steamIdsOnGeForceNow.has(steamID); // Check it against the list of known IDs, fetched from the GFN Games Page API
 }
 

--- a/getSteamIds.js
+++ b/getSteamIds.js
@@ -1,3 +1,6 @@
+// WARNING: Don't include this in manifest.json or it'll auto-execute on every page
+
+
 /* This is the official API used by the GFN Games Page at https://www.nvidia.com/en-us/geforce-now/games/
 While officially undocumented, a third-party developer, Ighor July (@JulyIghor at https://github.com/JulyIghor), documented its inner workings in a blog post: https://ighor.medium.com/i-unlocked-nvidia-geforce-now-and-stumbled-upon-pirates-dc48a3f8ff7
  */

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
     {
       "matches": ["https://store.steampowered.com/*"],
       "css": ["extstyles.css"],
-      "js": ["data.js", "contentScript.js", "getSteamIds.js"]
+      "js": ["data.js", "contentScript.js"]
     }
   ],
   "action": {


### PR DESCRIPTION
- Fixed wishlist page
- Removed getSteamIds.js from the manifest so it doesn't automatically run on every page (sorry, my bad!)
- I could not reproduce the game page bug. I didn't change the line that touches `document.getElementById("appHubAppName")`... hmm. Could this be a race condition? I saw [some other async loading issues](https://github.com/mefaba/show-geforce-on-steam/issues/13) where the observers were watching for elements that didn't exist yet (will have to debug later).

Screenshot 1: Fixed wishlist
![image](https://github.com/mefaba/show-geforce-on-steam/assets/11964962/a378d542-7a9d-4c58-ae8e-a8157fb688de)

Screenshot 2: Game page working (no change in this PR)
![image](https://github.com/mefaba/show-geforce-on-steam/assets/11964962/713579fb-2d11-4e28-b80d-f9c51130de43)
